### PR TITLE
Add .puppet-lint.rc file to module_files for ignoring checks

### DIFF
--- a/lib/retrospec/templates/module_files/.puppet-lint.rc
+++ b/lib/retrospec/templates/module_files/.puppet-lint.rc
@@ -1,0 +1,8 @@
+# Use this file to instruct puppet-lint to ignore certain checks.
+# For the complete list of checks and flags to disable them,
+# refer to <http://puppet-lint.com/checks/>.
+
+# Examples (uncomment before use):
+#--no-80chars-check
+#--no-class_inherits_from_params_class-check
+#--no-inherits_across_namespaces-check


### PR DESCRIPTION
The .puppet-lint-rc file is used by puppet-lint to ignore certain
style checks. By adding this file to module_files retrospec can
automatically create it when run. By default, the .puppet-lint.rc
file includes some example flags that are commented out and will
have no effect.