### PR TITLE
Add additional entries to .gitignore.erb

### DIFF
--- a/lib/retrospec/templates/module_files/.gitignore.erb
+++ b/lib/retrospec/templates/module_files/.gitignore.erb
@@ -6,3 +6,6 @@ spec/fixtures
 .bundle
 vendor
 .idea
+.project
+.DS_Store
+


### PR DESCRIPTION
Add `.project` and `.DS_Store` to the .gitignore.erb template. The project
dot-file is created by [Geppetto](https://docs.puppetlabs.com/geppetto/latest/).
The DS_Store dot-file is left behind everywhere OS X's Finder goes.